### PR TITLE
[Refactor] 좋아요 테이블 이름 변경 [#1]

### DIFF
--- a/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikeEntity.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikeEntity.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "like")
+@Table(name = "likes")
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor


### PR DESCRIPTION
## 연관된 이슈
#1 
<br>

## 작업 내용
- 기존의 테이블 이름인 like가 mariadb의 예약어로 사용되어 해당 이름을 likes로 변경했습니다.
<br> 

## 전달 사항
