### PR TITLE
[Feat] 프로그램 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -19,6 +19,8 @@ public enum BaseResponseStatus {
     EXCHANGE_OFFER_SUCCESS(true, 1002, "교환 요청에 성공하였습니다."),
     EXCHANGE_APPROVAL_SUCCESS(true, 1003, "티켓 교환에 성공하였습니다."),
     EXCHANGE_REJECT_SUCCESS(true, 1004, "티켓 거절에 성공하였습니다."),
+    LIKE_ADD_SUCCESS(true, 1005, "프로그램을 성공적으로 좋아요 목록에 추가했습니다."),
+    LIKE_DELETE_SUCCESS(true, 1006, "프로그램을 좋아요 목록에서 성공적으로 삭제했습니다."),
 
 
     /**
@@ -28,7 +30,7 @@ public enum BaseResponseStatus {
     USER_EMPTY_EMAIL(false, 2001, "이메일 등록란은 필수 항목입니다."),
     USER_EMPTY_NAME(false, 2002, "이름 등록란은 필수 항목입니다."),
     USER_EMPTY_PASSWORD(false, 2003, "패스워드 입력란은 필수 항목입니다."),
-    EXISTED_EMAIL(false,2004,"이미 가입된 이메일(아이디)입니다."),
+    EXISTED_EMAIL(false, 2004, "이미 가입된 이메일(아이디)입니다."),
     POINT_NOT_ENOUGH(false, 2101, "소유 포인트 보다 높은 포인트는 사용할 수 없습니다."),
 
 
@@ -82,9 +84,9 @@ public enum BaseResponseStatus {
     NOT_FOUND_RESERVATION(false, 5001, "결제 정보가 존재하지 않습니다."),
     NOT_FOUND_TIMES(false, 5002, "회차 정보가 존재하지 않습니다."),
     NOT_FOUND_SEAT(false, 5003, "좌석 정보가 존재하지 않습니다."),
-    NOT_MATCH_ROW(false,5004,"행 정보가 일치하지 않습니다."),
-    NOT_MATCH_COLUMN(false,5004,"열 정보가 일치하지 않습니다."),
-    NOT_EXIST_TIMES(false,5005,"공연 회차정보가 존재하지 않습니다."),
+    NOT_MATCH_ROW(false, 5004, "행 정보가 일치하지 않습니다."),
+    NOT_MATCH_COLUMN(false, 5004, "열 정보가 일치하지 않습니다."),
+    NOT_EXIST_TIMES(false, 5005, "공연 회차정보가 존재하지 않습니다."),
 
 
     /**

--- a/src/main/java/com/gamja/tiggle/like/adapter/in/web/CreateLikeController.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/in/web/CreateLikeController.java
@@ -1,0 +1,48 @@
+package com.gamja.tiggle.like.adapter.in.web;
+
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.common.annotation.WebAdapter;
+import com.gamja.tiggle.like.application.port.in.CreateLikeCommand;
+import com.gamja.tiggle.like.application.port.in.CreateLikeUseCase;
+import com.gamja.tiggle.user.domain.CustomUserDetails;
+import com.gamja.tiggle.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@WebAdapter
+@RequiredArgsConstructor
+@RequestMapping("/like")
+public class CreateLikeController {
+
+    private final CreateLikeUseCase createLikeUseCase;
+
+    @PostMapping("/{programId}")
+    @Operation(summary = "좋아요 토글", description = "사용자가 프로그램에 좋아요를 추가하거나, 기존 좋아요를 취소할 수 있는 API 입니다.")
+    public BaseResponse<BaseResponseStatus> createLike(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable Long programId) {
+        User user = customUserDetails.getUser();
+
+        CreateLikeCommand command = CreateLikeCommand.builder()
+                .user(user)
+                .programId(programId)
+                .build();
+
+        boolean isLike;
+
+        try {
+            isLike = createLikeUseCase.toggleLike(command);
+
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(isLike ? BaseResponseStatus.LIKE_ADD_SUCCESS : BaseResponseStatus.LIKE_DELETE_SUCCESS);
+    }
+}

--- a/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/JpaLikeRepository.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/JpaLikeRepository.java
@@ -1,6 +1,11 @@
 package com.gamja.tiggle.like.adapter.out.persistence;
 
+import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
+import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaLikeRepository extends JpaRepository<LikeEntity, Long> {
+    boolean existsByUserEntityAndProgramEntity(UserEntity userEntity, ProgramEntity programEntity);
+
+    void deleteByUserEntityAndProgramEntity(UserEntity userEntity, ProgramEntity programEntity);
 }

--- a/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikeEntity.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikeEntity.java
@@ -1,6 +1,5 @@
 package com.gamja.tiggle.like.adapter.out.persistence;
 
-import com.gamja.tiggle.program.adapter.out.persistence.Entity.LocationEntity;
 import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
 import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikePersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikePersistenceAdapter.java
@@ -1,0 +1,46 @@
+package com.gamja.tiggle.like.adapter.out.persistence;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.common.annotation.PersistenceAdapter;
+import com.gamja.tiggle.like.application.port.in.CreateLikeCommand;
+import com.gamja.tiggle.like.application.port.out.LikePort;
+import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
+import com.gamja.tiggle.program.adapter.out.persistence.JpaProgramRepository;
+import com.gamja.tiggle.user.adapter.out.persistence.JpaUserRepository;
+import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
+import lombok.RequiredArgsConstructor;
+
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class LikePersistenceAdapter implements LikePort {
+    private final JpaLikeRepository likeRepository;
+    private final JpaProgramRepository programRepository;
+    private final JpaUserRepository userRepository;
+
+    @Override
+    public boolean isLikedByUser(CreateLikeCommand command) {
+        return likeRepository.existsByUserEntityAndProgramEntity(UserEntity.builder().id(command.getUser().getId()).build(), ProgramEntity.builder().id(command.getProgramId()).build());
+    }
+
+    @Override
+    public void like(CreateLikeCommand command) throws BaseException {
+
+        ProgramEntity programEntity = programRepository.findById(command.getProgramId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_PROGRAM));
+
+        UserEntity userEntity = userRepository.findById(command.getUser().getId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_USER));
+
+        likeRepository.save(LikeEntity.builder()
+                .userEntity(userEntity)
+                .programEntity(programEntity)
+                .build());
+    }
+
+    @Override
+    public void unlike(CreateLikeCommand command) {
+        likeRepository.deleteByUserEntityAndProgramEntity(UserEntity.builder().id(command.getUser().getId()).build(), ProgramEntity.builder().id(command.getProgramId()).build());
+    }
+}

--- a/src/main/java/com/gamja/tiggle/like/application/port/in/CreateLikeCommand.java
+++ b/src/main/java/com/gamja/tiggle/like/application/port/in/CreateLikeCommand.java
@@ -1,0 +1,12 @@
+package com.gamja.tiggle.like.application.port.in;
+
+import com.gamja.tiggle.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CreateLikeCommand {
+    private User user;
+    private Long programId;
+}

--- a/src/main/java/com/gamja/tiggle/like/application/port/in/CreateLikeUseCase.java
+++ b/src/main/java/com/gamja/tiggle/like/application/port/in/CreateLikeUseCase.java
@@ -1,0 +1,7 @@
+package com.gamja.tiggle.like.application.port.in;
+
+import com.gamja.tiggle.common.BaseException;
+
+public interface CreateLikeUseCase {
+    boolean toggleLike(CreateLikeCommand command) throws BaseException;
+}

--- a/src/main/java/com/gamja/tiggle/like/application/port/out/LikePort.java
+++ b/src/main/java/com/gamja/tiggle/like/application/port/out/LikePort.java
@@ -1,0 +1,11 @@
+package com.gamja.tiggle.like.application.port.out;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.like.application.port.in.CreateLikeCommand;
+
+
+public interface LikePort {
+    boolean isLikedByUser(CreateLikeCommand command);
+    void like(CreateLikeCommand command) throws BaseException;
+    void unlike(CreateLikeCommand command);
+}

--- a/src/main/java/com/gamja/tiggle/like/application/service/CreateLikeService.java
+++ b/src/main/java/com/gamja/tiggle/like/application/service/CreateLikeService.java
@@ -1,0 +1,28 @@
+package com.gamja.tiggle.like.application.service;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.annotation.UseCase;
+import com.gamja.tiggle.like.application.port.in.CreateLikeCommand;
+import com.gamja.tiggle.like.application.port.in.CreateLikeUseCase;
+import com.gamja.tiggle.like.application.port.out.LikePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateLikeService implements CreateLikeUseCase {
+    private final LikePort likePort;
+
+
+    @Override
+    @Transactional
+    public boolean toggleLike(CreateLikeCommand command) throws BaseException {
+        if (likePort.isLikedByUser(command)) {
+            likePort.unlike(command);
+            return false;
+        } else {
+            likePort.like(command);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
#1 
<br>

## 작업 내용
- 좋아요 토글 기능 구현
  -  Controller에서 `/like/{programId}` 엔드포인트를 통해, 해당 프로그램에 대한 좋아요를 추가하거나 취소할 수 있는 API를 구현했습니다. 
  - 프론트엔드에서 좋아요 및 좋아요 취소 요청을 별도로 구분할 필요 없이 간편하게 사용하도록, 백엔드 서버에서 상태 변경을 관리하여 일관성을 유지하도록 구현했습니다.
  - 사용자의 요청에 따라 좋아요 여부를 확인 후, 그에 맞는 응답 메시지를 반환합니다.
- JpaLikeRepository에 메서드 구현
  - 특정 사용자와 프로그램을 기준으로 좋아요 여부를 확인하는 메서드를 구현했습니다.
  - 특정 사용자와 프로그램에 대한 좋아요 데이터를 삭제하는 메서드를 추가하여, 좋아요 취소 기능을 구현했니다.

<br> 

## 전달 사항
close #1 