### PR TITLE
[Feat] 공연 검색 기능 구현 [#7]

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -60,6 +60,14 @@ public enum BaseResponseStatus {
     INVALID_LOCATION_DATA(false, 3304, "유효하지 않은 로케이션 데이터입니다."),
     PROGRAM_NOT_IN_LOCATION(false, 3305, "해당 공연장에 해당 공연이 존재하지 않습니다."),
 
+    SEARCH_PROGRAM_SUCCESS(true, 3204, "공연 검색을 성공했습니다."),
+    SEARCH_PROGRAM_FAIL(false, 3205, "공연 검색을 실패했습니다."),
+    CATEGORY_PROGRAM_SUCCESS(true, 3206, "카테고리별 공연 검색을 성공했습니다."),
+    CATEGORY_PROGRAM_FAIL(false, 3207, "카테고리별 공연 검색을 실패했습니다."),
+
+    INVALID_PAGE(false, 3400, "유효하지 않은 페이지 번호입니다."),
+    INVALID_SIZE(false, 3401, "유효하지 않은 페이지 크기입니다."),
+
     /**
      * 4000: 결제
      */

--- a/src/main/java/com/gamja/tiggle/program/adapter/in/web/ReadProgramController.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/in/web/ReadProgramController.java
@@ -50,9 +50,9 @@ public class ReadProgramController {
                             .locationName(p.getLocationName())
                             .build())
                     .collect(Collectors.toList());
-            return new BaseResponse<>(BaseResponseStatus.SUCCESS, responses);
+            return new BaseResponse<>(BaseResponseStatus.CATEGORY_PROGRAM_SUCCESS, responses);
         } catch (BaseException e) {
-            return new BaseResponse<>(BaseResponseStatus.FAIL, null);
+            return new BaseResponse<>(BaseResponseStatus.CATEGORY_PROGRAM_FAIL, null);
         }
     }
 
@@ -87,7 +87,39 @@ public class ReadProgramController {
 
     }
 
+    // keyword 별로 공연 검색
+    @GetMapping("/search")
+    @Operation(summary = "공연 검색")
+    public BaseResponse<List<ReadProgramResponse>> search(@RequestParam String keyword,
+                                                          @RequestParam Integer page,
+                                                          @RequestParam Integer size) {
+        try {
+            validatePageRequest(page, size);
 
+            ReadProgramCommand command = ReadProgramCommand.builder()
+                    .keyword(keyword)
+                    .page(page)
+                    .size(size)
+                    .build();
+            List<Program> program = readUseCase.searchPrograms(command);
+            List<ReadProgramResponse> responses = program.stream()
+                    .map(p -> ReadProgramResponse.builder()
+                            .programId(p.getId())
+                            .programName(p.getProgramName())
+                            .reservationOpenDate(p.getReservationOpenDate())
+                            .programInfo(p.getProgramInfo())
+                            .programStartDate(p.getProgramStartDate())
+                            .programEndDate(p.getProgramEndDate())
+                            .imageFiles(p.getImageUrls())
+                            .locationName(p.getLocationName())
+                            .build())
+                    .collect(Collectors.toList());
+
+            return new BaseResponse<>(BaseResponseStatus.SEARCH_PROGRAM_SUCCESS, responses);
+        } catch (BaseException e) {
+            return new BaseResponse<>(BaseResponseStatus.SEARCH_PROGRAM_FAIL, null);
+        }
+    }
 
     // 프로그램 상세 조회
     @GetMapping
@@ -120,6 +152,16 @@ public class ReadProgramController {
                 .programInfo(program.getProgramInfo())
                 .runtime(program.getRuntime())
                 .build();
+    }
+
+    // 다른 페이지 값이 들어올 경우 예외처리
+    private void validatePageRequest(Integer page, Integer size) throws BaseException {
+        if (page == null || page < 0) {
+            throw new BaseException(BaseResponseStatus.INVALID_PAGE);
+        }
+        if (size == null || size <= 0) {
+            throw new BaseException(BaseResponseStatus.INVALID_SIZE);
+        }
     }
 
 }

--- a/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/JpaProgramRepository.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/JpaProgramRepository.java
@@ -5,10 +5,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaProgramRepository extends JpaRepository<ProgramEntity, Long> {
     @Query("SELECT p FROM ProgramEntity p JOIN FETCH p.categoryEntity c WHERE c.id = :categoryId")
     Page<ProgramEntity> findAllByCategoryEntity (Long categoryId, Pageable pageable);
+
+    @Query("SELECT p FROM ProgramEntity p WHERE p.programName LIKE %:keyword% OR p.programInfo LIKE %:keyword%")
+    Page<ProgramEntity> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     @Query("SELECT p.locationEntity.id FROM ProgramEntity p WHERE p.id = :programId")
     Long findLocationIdById(Long programId);

--- a/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
@@ -163,6 +163,29 @@ public class ProgramPersistenceAdapter implements CreateProgramPort, ReadProgram
     }
 
     @Override
+    public List<Program> searchProgram(ReadProgramCommand command) throws BaseException {
+        Pageable pageable = PageRequest.of(command.getPage(), command.getSize(), Sort.by(Sort.Direction.DESC, "reservationOpenDate"));
+
+        Page<ProgramEntity> result = jpaProgramRepository.findByKeyword(command.getKeyword(), pageable);
+
+        return result.getContent().stream().map(
+                (p) -> Program.builder()
+                        .id(p.getId())
+                        .categoryId(p.getCategoryEntity().getId())
+                        .programName(p.getProgramName())
+                        .programInfo(p.getProgramInfo())
+                        .reservationOpenDate(p.getReservationOpenDate())
+                        .programStartDate(p.getProgramStartDate())
+                        .programEndDate(p.getProgramEndDate())
+                        .imageUrls(p.getProgramImageEntities().stream()
+                                .map(ProgramImageEntity::getImgUrl)
+                                .collect(Collectors.toList()))
+                        .locationName(p.getLocationEntity().getLocationName())
+                        .build()
+        ).collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
     public boolean existProgram(Long id) throws BaseException {
         if(!jpaProgramRepository.existsById(id)){
             throw new BaseException(BaseResponseStatus.NOT_FOUND_PROGRAM);

--- a/src/main/java/com/gamja/tiggle/program/application/port/in/ReadProgramCommand.java
+++ b/src/main/java/com/gamja/tiggle/program/application/port/in/ReadProgramCommand.java
@@ -12,6 +12,7 @@ public class ReadProgramCommand {
     private Long categoryId;
     private Long locationId;
     private LocalDateTime currentDateTime;
+    private String keyword;
 
     // 페이징 처리 하려고
     private Integer page;

--- a/src/main/java/com/gamja/tiggle/program/application/port/in/ReadProgramUseCase.java
+++ b/src/main/java/com/gamja/tiggle/program/application/port/in/ReadProgramUseCase.java
@@ -11,6 +11,7 @@ public interface ReadProgramUseCase {
     List<Program> readProgramAll(ReadProgramCommand command) throws BaseException;
     List<Program> readRealTimeAll(ReadProgramCommand command) throws BaseException;
     List<Program> readRealTimeAllPaged(ReadProgramCommand command) throws BaseException;
+    List<Program> searchPrograms(ReadProgramCommand command) throws BaseException;
     Program GetProgramDetail(Long id) throws BaseException;
 }
 

--- a/src/main/java/com/gamja/tiggle/program/application/port/out/ReadProgramPort.java
+++ b/src/main/java/com/gamja/tiggle/program/application/port/out/ReadProgramPort.java
@@ -11,7 +11,7 @@ public interface ReadProgramPort {
     List<Program> readProgramAll(Program program, ReadProgramCommand command) throws BaseException;
     List<Program> readRealTimeAll(LocalDateTime currentDateTime) throws BaseException;
     List<Program> readRealTimeAllPaged(ReadProgramCommand command) throws BaseException;
-
+    List<Program> searchProgram(ReadProgramCommand command) throws BaseException;
     Program getProgramDetail(Long id) throws BaseException;
 
 }

--- a/src/main/java/com/gamja/tiggle/program/application/service/ReadProgramService.java
+++ b/src/main/java/com/gamja/tiggle/program/application/service/ReadProgramService.java
@@ -33,6 +33,11 @@ public class ReadProgramService implements ReadProgramUseCase {
     }
 
     @Override
+    public List<Program> searchPrograms(ReadProgramCommand command) throws BaseException {
+        return readProgramPort.searchProgram(command);
+    }
+
+    @Override
     public List<Program> readRealTimeAllPaged(ReadProgramCommand command) throws BaseException {
         return readProgramPort.readRealTimeAllPaged(command);
     }


### PR DESCRIPTION
## 연관된 이슈
#7 
<br>

## 작업 내용
- 공연 검색 기능 구현
  - `/program/search?keyword=2024&page=0&size=1` 예시 엔드포인트를 통해 받아온 keyword 값에 따라 검색 결과가 바뀌는 API를 구현 했습니다. 
- 저번 코드 리뷰를 참고 하여, 페이징 처리를 했을 때 0보다 작은 값이 들어오거나, null일 경우 예외처리 되도록 추가 해 뒀습니다.
<br> 

## 전달 사항
close #7