### PR TITLE
[Feat] 나의 좋아요 목록 조회 기능 구현 [#4]

### DIFF
--- a/src/main/java/com/gamja/tiggle/like/adapter/in/web/ReadLikeController.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/in/web/ReadLikeController.java
@@ -4,6 +4,7 @@ package com.gamja.tiggle.like.adapter.in.web;
 import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.common.annotation.WebAdapter;
 import com.gamja.tiggle.like.adapter.in.web.response.ReadMyLikeResponse;
+import com.gamja.tiggle.like.application.port.in.ReadLikeCommand;
 import com.gamja.tiggle.like.application.port.in.ReadLikeUseCase;
 import com.gamja.tiggle.user.domain.CustomUserDetails;
 import com.gamja.tiggle.user.domain.User;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -23,10 +25,16 @@ public class ReadLikeController {
 
     @GetMapping("/my")
     @Operation(summary = "나의 좋아요 조회", description = "사용자가 프로그램에 좋아요 한 공연들을 조회하는 API 입니다.")
-    public BaseResponse<List<ReadMyLikeResponse>> readMyLikes(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public BaseResponse<List<ReadMyLikeResponse>> readMyLikes(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestParam int page,  @RequestParam int size) {
         User user = customUserDetails.getUser();
 
-        List<ReadMyLikeResponse> myLikeResponseList = readLikeUseCase.readMyLikes(user);
+        ReadLikeCommand command = ReadLikeCommand.builder()
+                .user(user)
+                .page(page)
+                .size(size)
+                .build();
+
+        List<ReadMyLikeResponse> myLikeResponseList = readLikeUseCase.readMyLikes(command);
 
         return new BaseResponse<>(myLikeResponseList);
     }

--- a/src/main/java/com/gamja/tiggle/like/adapter/in/web/ReadLikeController.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/in/web/ReadLikeController.java
@@ -1,0 +1,34 @@
+package com.gamja.tiggle.like.adapter.in.web;
+
+
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.annotation.WebAdapter;
+import com.gamja.tiggle.like.adapter.in.web.response.ReadMyLikeResponse;
+import com.gamja.tiggle.like.application.port.in.ReadLikeUseCase;
+import com.gamja.tiggle.user.domain.CustomUserDetails;
+import com.gamja.tiggle.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@WebAdapter
+@RequiredArgsConstructor
+@RequestMapping("/like")
+public class ReadLikeController {
+    private final ReadLikeUseCase readLikeUseCase;
+
+    @GetMapping("/my")
+    @Operation(summary = "나의 좋아요 조회", description = "사용자가 프로그램에 좋아요 한 공연들을 조회하는 API 입니다.")
+    public BaseResponse<List<ReadMyLikeResponse>> readMyLikes(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        User user = customUserDetails.getUser();
+
+        List<ReadMyLikeResponse> myLikeResponseList = readLikeUseCase.readMyLikes(user);
+
+        return new BaseResponse<>(myLikeResponseList);
+    }
+
+}

--- a/src/main/java/com/gamja/tiggle/like/adapter/in/web/response/ReadMyLikeResponse.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/in/web/response/ReadMyLikeResponse.java
@@ -1,0 +1,14 @@
+package com.gamja.tiggle.like.adapter.in.web.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ReadMyLikeResponse {
+    private Long id;
+    private String imageUrl;
+    private String title;
+    private String location;
+    private String date;
+}

--- a/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/JpaLikeRepository.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/JpaLikeRepository.java
@@ -2,6 +2,8 @@ package com.gamja.tiggle.like.adapter.out.persistence;
 
 import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
 import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,5 +20,5 @@ public interface JpaLikeRepository extends JpaRepository<LikeEntity, Long> {
             "JOIN FETCH l.programEntity p " +
             "JOIN FETCH p.locationEntity loc " +
             "WHERE l.userEntity.id = :userId")
-    List<LikeEntity> findLikesWithProgramAndLocationByUserId(@Param("userId") Long userId);
+    Page<LikeEntity> findLikesWithProgramAndLocationByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/JpaLikeRepository.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/JpaLikeRepository.java
@@ -3,9 +3,20 @@ package com.gamja.tiggle.like.adapter.out.persistence;
 import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
 import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface JpaLikeRepository extends JpaRepository<LikeEntity, Long> {
     boolean existsByUserEntityAndProgramEntity(UserEntity userEntity, ProgramEntity programEntity);
 
     void deleteByUserEntityAndProgramEntity(UserEntity userEntity, ProgramEntity programEntity);
+
+
+    @Query("SELECT l FROM LikeEntity l " +
+            "JOIN FETCH l.programEntity p " +
+            "JOIN FETCH p.locationEntity loc " +
+            "WHERE l.userEntity.id = :userId")
+    List<LikeEntity> findLikesWithProgramAndLocationByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikePersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikePersistenceAdapter.java
@@ -7,9 +7,13 @@ import com.gamja.tiggle.like.application.port.in.CreateLikeCommand;
 import com.gamja.tiggle.like.application.port.out.LikePort;
 import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
 import com.gamja.tiggle.program.adapter.out.persistence.JpaProgramRepository;
+import com.gamja.tiggle.program.domain.Program;
 import com.gamja.tiggle.user.adapter.out.persistence.JpaUserRepository;
 import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
+import com.gamja.tiggle.user.domain.User;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 
 @PersistenceAdapter
@@ -42,5 +46,25 @@ public class LikePersistenceAdapter implements LikePort {
     @Override
     public void unlike(CreateLikeCommand command) {
         likeRepository.deleteByUserEntityAndProgramEntity(UserEntity.builder().id(command.getUser().getId()).build(), ProgramEntity.builder().id(command.getProgramId()).build());
+    }
+
+    @Override
+    public List<Program> readMyLikes(User user)  {
+       List<LikeEntity> likes = likeRepository.findLikesWithProgramAndLocationByUserId(user.getId());
+
+        List<Program> programs = likes.stream().map(
+                l -> Program.builder()
+                        .locationName(l.getProgramEntity().getLocationEntity().getLocationName())
+                        .programName(l.getProgramEntity().getProgramName())
+                        .programStartDate(l.getProgramEntity().getProgramStartDate())
+                        .programEndDate(l.getProgramEntity().getProgramEndDate())
+                        .id(l.getProgramEntity().getId())
+                        .imageUrls(l.getProgramEntity().getProgramImageEntities().stream()
+                        .map(programImageEntity -> programImageEntity.getImgUrl())
+                        .toList())
+                        .build()
+        ).toList();
+
+        return programs;
     }
 }

--- a/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikePersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/like/adapter/out/persistence/LikePersistenceAdapter.java
@@ -4,14 +4,17 @@ import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.common.annotation.PersistenceAdapter;
 import com.gamja.tiggle.like.application.port.in.CreateLikeCommand;
+import com.gamja.tiggle.like.application.port.in.ReadLikeCommand;
 import com.gamja.tiggle.like.application.port.out.LikePort;
 import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
 import com.gamja.tiggle.program.adapter.out.persistence.JpaProgramRepository;
 import com.gamja.tiggle.program.domain.Program;
 import com.gamja.tiggle.user.adapter.out.persistence.JpaUserRepository;
 import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
-import com.gamja.tiggle.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -49,8 +52,9 @@ public class LikePersistenceAdapter implements LikePort {
     }
 
     @Override
-    public List<Program> readMyLikes(User user)  {
-       List<LikeEntity> likes = likeRepository.findLikesWithProgramAndLocationByUserId(user.getId());
+    public List<Program> readMyLikes(ReadLikeCommand command)  {
+        Pageable pageable = PageRequest.of(command.getPage(), command.getSize());
+       Page<LikeEntity> likes = likeRepository.findLikesWithProgramAndLocationByUserId(command.getUser().getId(), pageable);
 
         List<Program> programs = likes.stream().map(
                 l -> Program.builder()

--- a/src/main/java/com/gamja/tiggle/like/application/port/in/ReadLikeCommand.java
+++ b/src/main/java/com/gamja/tiggle/like/application/port/in/ReadLikeCommand.java
@@ -1,0 +1,14 @@
+package com.gamja.tiggle.like.application.port.in;
+
+
+import com.gamja.tiggle.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ReadLikeCommand {
+    private User user;
+    private int size;
+    private int page;
+}

--- a/src/main/java/com/gamja/tiggle/like/application/port/in/ReadLikeUseCase.java
+++ b/src/main/java/com/gamja/tiggle/like/application/port/in/ReadLikeUseCase.java
@@ -1,10 +1,9 @@
 package com.gamja.tiggle.like.application.port.in;
 
 import com.gamja.tiggle.like.adapter.in.web.response.ReadMyLikeResponse;
-import com.gamja.tiggle.user.domain.User;
 
 import java.util.List;
 
 public interface ReadLikeUseCase {
-    List<ReadMyLikeResponse> readMyLikes(User user);
+    List<ReadMyLikeResponse> readMyLikes(ReadLikeCommand command);
 }

--- a/src/main/java/com/gamja/tiggle/like/application/port/in/ReadLikeUseCase.java
+++ b/src/main/java/com/gamja/tiggle/like/application/port/in/ReadLikeUseCase.java
@@ -1,0 +1,10 @@
+package com.gamja.tiggle.like.application.port.in;
+
+import com.gamja.tiggle.like.adapter.in.web.response.ReadMyLikeResponse;
+import com.gamja.tiggle.user.domain.User;
+
+import java.util.List;
+
+public interface ReadLikeUseCase {
+    List<ReadMyLikeResponse> readMyLikes(User user);
+}

--- a/src/main/java/com/gamja/tiggle/like/application/port/out/LikePort.java
+++ b/src/main/java/com/gamja/tiggle/like/application/port/out/LikePort.java
@@ -2,8 +2,8 @@ package com.gamja.tiggle.like.application.port.out;
 
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.like.application.port.in.CreateLikeCommand;
+import com.gamja.tiggle.like.application.port.in.ReadLikeCommand;
 import com.gamja.tiggle.program.domain.Program;
-import com.gamja.tiggle.user.domain.User;
 
 import java.util.List;
 
@@ -12,5 +12,5 @@ public interface LikePort {
     boolean isLikedByUser(CreateLikeCommand command);
     void like(CreateLikeCommand command) throws BaseException;
     void unlike(CreateLikeCommand command);
-    List<Program> readMyLikes(User user);
+    List<Program> readMyLikes(ReadLikeCommand command);
 }

--- a/src/main/java/com/gamja/tiggle/like/application/port/out/LikePort.java
+++ b/src/main/java/com/gamja/tiggle/like/application/port/out/LikePort.java
@@ -2,10 +2,15 @@ package com.gamja.tiggle.like.application.port.out;
 
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.like.application.port.in.CreateLikeCommand;
+import com.gamja.tiggle.program.domain.Program;
+import com.gamja.tiggle.user.domain.User;
+
+import java.util.List;
 
 
 public interface LikePort {
     boolean isLikedByUser(CreateLikeCommand command);
     void like(CreateLikeCommand command) throws BaseException;
     void unlike(CreateLikeCommand command);
+    List<Program> readMyLikes(User user);
 }

--- a/src/main/java/com/gamja/tiggle/like/application/service/ReadLikeService.java
+++ b/src/main/java/com/gamja/tiggle/like/application/service/ReadLikeService.java
@@ -2,10 +2,10 @@ package com.gamja.tiggle.like.application.service;
 
 import com.gamja.tiggle.common.annotation.UseCase;
 import com.gamja.tiggle.like.adapter.in.web.response.ReadMyLikeResponse;
+import com.gamja.tiggle.like.application.port.in.ReadLikeCommand;
 import com.gamja.tiggle.like.application.port.in.ReadLikeUseCase;
 import com.gamja.tiggle.like.application.port.out.LikePort;
 import com.gamja.tiggle.program.domain.Program;
-import com.gamja.tiggle.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -19,8 +19,8 @@ public class ReadLikeService implements ReadLikeUseCase {
     private final LikePort likePort;
 
     @Override
-    public List<ReadMyLikeResponse> readMyLikes(User user) {
-        List<Program> programs = likePort.readMyLikes(user);
+    public List<ReadMyLikeResponse> readMyLikes(ReadLikeCommand command) {
+        List<Program> programs = likePort.readMyLikes(command);
 
         List<ReadMyLikeResponse> responses = programs.stream().map(p -> ReadMyLikeResponse.builder()
                 .title(p.getProgramName())

--- a/src/main/java/com/gamja/tiggle/like/application/service/ReadLikeService.java
+++ b/src/main/java/com/gamja/tiggle/like/application/service/ReadLikeService.java
@@ -1,0 +1,47 @@
+package com.gamja.tiggle.like.application.service;
+
+import com.gamja.tiggle.common.annotation.UseCase;
+import com.gamja.tiggle.like.adapter.in.web.response.ReadMyLikeResponse;
+import com.gamja.tiggle.like.application.port.in.ReadLikeUseCase;
+import com.gamja.tiggle.like.application.port.out.LikePort;
+import com.gamja.tiggle.program.domain.Program;
+import com.gamja.tiggle.user.domain.User;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class ReadLikeService implements ReadLikeUseCase {
+    private final LikePort likePort;
+
+    @Override
+    public List<ReadMyLikeResponse> readMyLikes(User user) {
+        List<Program> programs = likePort.readMyLikes(user);
+
+        List<ReadMyLikeResponse> responses = programs.stream().map(p -> ReadMyLikeResponse.builder()
+                .title(p.getProgramName())
+                .id(p.getId())
+                .imageUrl(p.getImageUrls().get(0))
+                .location(p.getLocationName())
+                .date(formatDateRange(p.getProgramStartDate(), p.getProgramEndDate()))
+                .build()
+        ).toList();
+
+        return responses;
+    }
+
+
+    public static String formatDateRange(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        String startDate = formatter.format(startDateTime);
+        String endDate = formatter.format(endDateTime);
+
+        return startDate + " - " + endDate;
+    }
+
+}


### PR DESCRIPTION
## 연관된 이슈
#4 
<br>

## 작업 내용
- 좋아요 목록 조회 시 페이징 기능을 추가하여 한 번에 많은 데이터를 반환하지 않고, 클라이언트가 요청한 페이지 크기에 따라 데이터를 분할하여 반환하도록 구현했습니다.

<br> 

## 전달 사항
- 좋아요 목록 조회 시, @BatchSize를 사용하여 n+1 문제를 해결하려 했으나 Hibernate 오류로 인해 적용하지 못한 상태입니다. 현재 페이징 처리로 조회 쿼리 수는 줄어들었지만, 프로그램 이미지나 연관된 엔티티를 로드하는 과정에서 여전히 n+1 문제가 발생할 가능성이 있어 향후 최적화를 위한 추가 작업이 필요합니다.

close #4