### PR TITLE
[Feat] 구역별 잔여좌석 조회 구현 [#3]

### DIFF
--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSectionController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSectionController.java
@@ -41,6 +41,7 @@ public class GetSectionController {
                         .sectionName(section.getSectionName())
                         .gradeName(section.getGradeName())
                         .price(section.getPrice())
+                        .remainingCount(section.getRemainingCount())
                         .build()
         ).toList();
     }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetSectionListResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetSectionListResponse.java
@@ -12,6 +12,7 @@ public class GetSectionListResponse {
     private Long gradeId;
     private String gradeName;
     private int price;
+    private Long remainingCount;
 
 
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SectionEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SectionEntity.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
@@ -30,5 +33,7 @@ public class SectionEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "grade_id")
     private GradeEntity gradeEntity;
+    @OneToMany(mappedBy = "sectionEntity")
+    private List<SeatEntity> seatEntities = new ArrayList<>();
 
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
@@ -20,7 +20,7 @@ public class GetSectionAdapter implements GetSectionPort {
 
     @Override
     public List<Section> getSection(Long locationId, Long programId) throws BaseException {
-        List<GetSectionResponse> allByLocationId = sectionRepository.findAllByLocationEntityId(locationId, programId);
+        List<GetSectionResponse> allByLocationId = sectionRepository.findAllByLocationEntityIdWithRemainingCount(locationId, programId);
         if (allByLocationId.isEmpty()) {
             throw new BaseException(BaseResponseStatus.NOT_FOUND_SECTION);
         }
@@ -50,6 +50,7 @@ public class GetSectionAdapter implements GetSectionPort {
                         .gradeName(sectionEntity.getGradeName())
                         .sectionName(sectionEntity.getSectionName())
                         .price(sectionEntity.getPrice())
+                        .remainingCount(sectionEntity.getRemainingCount())
                         .build()
         ).toList();
     }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Response/GetSectionResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Response/GetSectionResponse.java
@@ -12,12 +12,14 @@ public class GetSectionResponse {
     private Long gradeId;
     private String gradeName;
     private int price;
+    private Long remainingCount;
 
-    public GetSectionResponse(Long sectionId, String sectionName, Long gradeId, String gradeName, int price) {
+    public GetSectionResponse(Long sectionId, String sectionName, Long gradeId, String gradeName, int price, long remainingCount) {
         this.sectionId = sectionId;
         this.sectionName = sectionName;
         this.gradeId = gradeId;
         this.gradeName = gradeName;
         this.price = price;
+        this.remainingCount = remainingCount;
     }
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
@@ -16,7 +16,7 @@ public interface SectionRepository extends JpaRepository<SectionEntity, Long> {
             " FROM SeatEntity seat " +
             " LEFT JOIN ReservationEntity re ON seat.id = re.seatEntity.id AND re.programEntity.id = :programId " +
             " WHERE seat.sectionEntity.id = s.id AND seat.active = TRUE " +
-            " AND (re.id IS NULL OR re.available = TRUE)) AS remainingCount) " +
+            " AND (re.id IS NULL OR re.available = TRUE))) " + // AS 제거
             "FROM SectionEntity s " +
             "JOIN s.gradeEntity g " +
             "JOIN ProgramGradeEntity pg ON g.id = pg.gradeEntity.id " +

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
@@ -10,16 +10,22 @@ import java.util.List;
 
 public interface SectionRepository extends JpaRepository<SectionEntity, Long> {
 
-    // TODO locationENtity ID
     @Query("SELECT NEW com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetSectionResponse(" +
-            "s.id, s.sectionName, s.gradeEntity.id, s.gradeEntity.gradeName, pg.price) " +
+            "s.id, s.sectionName, s.gradeEntity.id, s.gradeEntity.gradeName, pg.price, " +
+            "(SELECT COUNT(seat.id) " +
+            " FROM SeatEntity seat " +
+            " LEFT JOIN ReservationEntity re ON seat.id = re.seatEntity.id AND re.programEntity.id = :programId " +
+            " WHERE seat.sectionEntity.id = s.id AND seat.active = TRUE " +
+            " AND (re.id IS NULL OR re.available = TRUE)) AS remainingCount) " +
             "FROM SectionEntity s " +
             "JOIN s.gradeEntity g " +
             "JOIN ProgramGradeEntity pg ON g.id = pg.gradeEntity.id " +
             "JOIN pg.programEntity p " +
             "WHERE s.locationEntity.id = :locationId " +
             "AND p.id = :programId")
-    List<GetSectionResponse> findAllByLocationEntityId(@Param("locationId") Long locationId, @Param("programId") Long ProgramId);
-
+    List<GetSectionResponse> findAllByLocationEntityIdWithRemainingCount(
+            @Param("locationId") Long locationId,
+            @Param("programId") Long programId
+    );
     Boolean existsByIdAndLocationEntityId(Long sectionId, Long LocationId);
 }

--- a/src/main/java/com/gamja/tiggle/reservation/domain/Section.java
+++ b/src/main/java/com/gamja/tiggle/reservation/domain/Section.java
@@ -13,6 +13,7 @@ public class Section {
     private Long gradeId;
     private String gradeName;
     private int price;
+    private Long remainingCount;
 
     private int rowCount; // 행
     private int columnCount; // 열


### PR DESCRIPTION
## 연관된 이슈
#3
<br>

## 작업 내용
- SeatEntity 테이블에서 Section_id가 s.id 와 같은 좌석을 찾아서 좌석이 활성화 된 (active= TRUE) 상태임을 확인 후 TRUE 인 좌석만 가지고 올 수 있도록 구현 했습니다.
- 구현 된 코드에서 벗어나지 않도록 관계만 맺는 방식으로 가지고 왔습니다. `http://localhost:8080/section?locationId=2&programId=1` 해당 API로 확인 가능합니다.

<br> 

## 전달 사항
구현 된 컨트롤러 내에서 구분을 하려고 했지만 feature/section 이라는 브랜치가 이미 존재 해 하위로 브랜치 이름을 가질 수 없었습니다. 그렇기에 section_seat-count 라고 / 없이 작성 했습니다 ! 

close #3 