### PR TITLE
[Refactor] 동시성 제어를 위한 redis 도입 [#17]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gamja/tiggle/config/RedisConfig.java
+++ b/src/main/java/com/gamja/tiggle/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package com.gamja.tiggle.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(host);
+        configuration.setPort(port);
+        configuration.setPassword(password);
+
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSectionController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSectionController.java
@@ -22,19 +22,19 @@ public class GetSectionController {
 
     @GetMapping
     @Operation(summary = "공연 구역 조회", description = "locationId를 입력하여 해당 공연장의 구역리스트를 조회하는 API 입니다.")
-    public BaseResponse<List<GetSectionListResponse>> getSection(@RequestParam Long locationId, @RequestParam Long programId,
+    public BaseResponse<List<GetSectionListResponse>> getSection(@RequestParam Long locationId, @RequestParam Long programId, @RequestParam Long timesId,
                                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         List<GetSectionListResponse> result;
         try {
-            result = getList(locationId,programId);
+            result = getList(locationId,programId, timesId);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
         return new BaseResponse<>(result);
     }
 
-    private List<GetSectionListResponse> getList(Long locationId, Long programId) throws BaseException {
-        return getSectionUseCase.getSection(locationId, programId).stream().map(section ->
+    private List<GetSectionListResponse> getList(Long locationId, Long programId, Long timesId) throws BaseException {
+        return getSectionUseCase.getSection(locationId, programId, timesId).stream().map(section ->
                 GetSectionListResponse.builder()
                         .id(section.getId())
                         .gradeId(section.getGradeId())

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/VerifySeatController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/VerifySeatController.java
@@ -42,7 +42,9 @@ public class VerifySeatController {
                 .programId(request.getProgramId())
                 .timesId(request.getTimesId())
                 .seatId(request.getSeatId())
+                .sectionId(request.getSectionId())
                 .userId(userId)
+                .totalPrice(request.getTotalPrice())
                 .build();
     }
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/request/VerifySeatRequest.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/request/VerifySeatRequest.java
@@ -9,11 +9,9 @@ import lombok.Getter;
 public class VerifySeatRequest {
 
     private Long seatId;
-    // 선택 후 예약 생성 때 쓸 필드값
-
     private Long programId;
-
     private Long timesId;
-
+    private Long sectionId;
+    private Integer totalPrice;
 
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/VerifySeatResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/VerifySeatResponse.java
@@ -8,5 +8,5 @@ import java.util.List;
 @Getter
 @Builder
 public class VerifySeatResponse {
-    private Long reservationId;
+    private String ticketNumber;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSeatAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSeatAdapter.java
@@ -3,12 +3,10 @@ package com.gamja.tiggle.reservation.adapter.out.persistence;
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.common.annotation.PersistenceAdapter;
-import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.SeatEntity;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetAllSeatPersistentResponse;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetAvailableExchangeSeatPersistenceResponse;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetAvailableSeatResponse;
-import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.ReservationRepository;
 import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.SeatRepository;
 import com.gamja.tiggle.reservation.application.port.out.GetSeatPort;
 import com.gamja.tiggle.reservation.domain.Seat;
@@ -16,63 +14,15 @@ import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.redis.core.RedisTemplate;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class getSeatAdapter implements GetSeatPort {
+public class GetSeatAdapter implements GetSeatPort {
 
     private final SeatRepository seatRepository;
-    private final ReservationRepository reservationRepository;
     private final RedisTemplate redisTemplate;
 
-    /**
-     * N+1 성능 문제 해결
-     * getAvailableSeatByJpa -> getAvailableSeatByQuery
-     */
-    @Override
-    public List<Seat> getAvailableSeatByJpa(Long programId, Long timesId, Long sectionId) throws BaseException {
-        // sectionId로 먼저 좌석 조회
-        List<SeatEntity> seats = seatRepository.findAllBySectionEntityId(sectionId).orElseThrow(() ->
-                new BaseException(BaseResponseStatus.NOT_FOUND_SEAT));
-
-
-        List<SeatEntity> result = new ArrayList<>();
-        for (SeatEntity seat : seats) {
-            // 좌석 ID, 프로그램 ID, 시간 ID로 예약 정보 조회
-            List<ReservationEntity> reservationList = reservationRepository.findBySeatEntityIdAndProgramEntityIdAndTimesEntityId(seat.getId(), programId, timesId);
-
-            // 예약 정보가 없는 경우, 해당 좌석을 결과 목록에 추가
-            if (reservationList.isEmpty()) {
-                result.add(seat);
-                continue;
-            }
-
-            ReservationEntity latestReservation = reservationList.get(0);
-            for (ReservationEntity reservation : reservationList) {
-                if ((reservation.getModifiedAt() != null && (latestReservation.getModifiedAt() == null || reservation.getModifiedAt().isAfter(latestReservation.getModifiedAt()))) ||
-                        (reservation.getModifiedAt() == null && reservation.getCreatedAt().isAfter(latestReservation.getCreatedAt()))) {
-                    latestReservation = reservation;
-                }
-            }
-
-            if (latestReservation.isAvailable()) {
-                result.add(seat);
-            }
-        }
-
-        List<Seat> list = result.stream().map(seatEntity ->
-                Seat.builder()
-                        .id(seatEntity.getId())
-                        .seatNumber(seatEntity.getSeatNumber())
-                        .sectionId(seatEntity.getSectionEntity().getId())
-                        .build()
-        ).collect(Collectors.toList());
-
-        return list;
-    }
 
     @Override
     public List<Seat> getAvailableSeatByQuery(Long programId, Long timesId, Long sectionId) {
@@ -130,7 +80,6 @@ public class getSeatAdapter implements GetSeatPort {
                 = seatRepository.findAllSeat(programId, timesId, sectionId);
 
         return getSeatListWithRedisStatus(programId, timesId, sectionId, allSeat);
-//        return getSeatList(allSeat);
     }
 
     @Override
@@ -143,17 +92,14 @@ public class getSeatAdapter implements GetSeatPort {
 
     @NotNull
     private List<Seat> getSeatListWithRedisStatus(Long programId, Long timesId, Long sectionId, List<GetAllSeatPersistentResponse> allSeat) {
+
+        String redisKey = "reservation:" + programId + ":" + timesId + ":" + sectionId;
+
         return allSeat.stream().map(response -> {
-            // Redis 키 생성
-            String redisKey = "seat:" + programId + ":" + timesId + ":" + sectionId + ":" + response.getSeatId();
+            boolean isLocked = redisTemplate.opsForSet().isMember(redisKey, response.getSeatId().toString());
 
-            // Redis에서 좌석 상태 조회
-            String redisStatus = (String) redisTemplate.opsForHash().get(redisKey, "status");
+            boolean enable = !isLocked && response.getEnable();
 
-            // Redis에 "LOCKED" 상태가 있으면 enable=false, 없으면 DB 값 사용
-            boolean enable = !"LOCKED".equals(redisStatus) && response.getEnable();
-
-            // Seat 객체 생성
             return Seat.builder()
                     .id(response.getSeatId())
                     .enable(enable) // Redis 상태 반영
@@ -164,20 +110,6 @@ public class getSeatAdapter implements GetSeatPort {
         }).toList();
     }
 
-    @NotNull
-    private static List<Seat> getSeatList(List<GetAllSeatPersistentResponse> allSeat) {
-        return allSeat.stream().map(response ->
-                Seat
-                        .builder()
-                        .id(response.getSeatId())
-                        .enable(response.getEnable())
-                        .seatNumber(response.getSeatNumber())
-                        .row(response.getRow())
-                        .active(response.getActive())
-                        .enable(response.getEnable())
-                        .build()
-        ).toList();
-    }
 
     @NotNull
     private static List<Seat> getExchangeSeatList(List<GetAvailableExchangeSeatPersistenceResponse> allSeat) {

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
@@ -9,6 +9,7 @@ import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.SectionRe
 import com.gamja.tiggle.reservation.application.port.out.GetSectionPort;
 import com.gamja.tiggle.reservation.domain.Section;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 
 import java.util.List;
 
@@ -17,14 +18,41 @@ import java.util.List;
 public class GetSectionAdapter implements GetSectionPort {
 
     private final SectionRepository sectionRepository;
+    private final RedisTemplate redisTemplate;
+
 
     @Override
-    public List<Section> getSection(Long locationId, Long programId) throws BaseException {
+    public List<Section> getSection(Long locationId, Long programId, Long timesId) throws BaseException {
         List<GetSectionResponse> allByLocationId = sectionRepository.findAllByLocationEntityIdWithRemainingCount(locationId, programId);
         if (allByLocationId.isEmpty()) {
             throw new BaseException(BaseResponseStatus.NOT_FOUND_SECTION);
         }
-        return from(allByLocationId);
+
+        return from(allByLocationId, programId, timesId);
+    }
+
+    private List<Section> from(List<GetSectionResponse> allByLocationId, Long programId, Long timesId) {
+        return allByLocationId.stream().map(sectionEntity -> {
+            Long inProgressCount = countInProgressReservations(programId, timesId, sectionEntity.getSectionId());
+
+            Long adjustedRemainingCount = sectionEntity.getRemainingCount() - (inProgressCount != null ? inProgressCount : 0);
+
+            return Section.builder()
+                    .id(sectionEntity.getSectionId())
+                    .locationId(sectionEntity.getSectionId())
+                    .gradeId(sectionEntity.getGradeId())
+                    .gradeName(sectionEntity.getGradeName())
+                    .sectionName(sectionEntity.getSectionName())
+                    .price(sectionEntity.getPrice())
+                    .remainingCount(adjustedRemainingCount)
+                    .build();
+        }).toList();
+    }
+
+    private Long countInProgressReservations(Long programId, Long timesId, Long sectionId) {
+        String redisKey = "reservation:" + programId + ":" + timesId + ":" + sectionId;
+
+        return redisTemplate.opsForSet().size(redisKey);
     }
 
     @Override
@@ -39,20 +67,6 @@ public class GetSectionAdapter implements GetSectionPort {
         if(!sectionRepository.existsByIdAndLocationEntityId(sectionId, locationId)){
             throw new BaseException(BaseResponseStatus.NOT_MATCH_SECTION);
         }
-    }
-
-    private List<Section> from(List<GetSectionResponse> allByLocationId) {
-        return allByLocationId.stream().map(sectionEntity ->
-                Section.builder()
-                        .id(sectionEntity.getSectionId())
-                        .locationId(sectionEntity.getSectionId())
-                        .gradeId(sectionEntity.getGradeId())
-                        .gradeName(sectionEntity.getGradeName())
-                        .sectionName(sectionEntity.getSectionName())
-                        .price(sectionEntity.getPrice())
-                        .remainingCount(sectionEntity.getRemainingCount())
-                        .build()
-        ).toList();
     }
 
     private Section from(SectionEntity entity) {

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/SaveReservationAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/SaveReservationAdapter.java
@@ -49,12 +49,14 @@ public class SaveReservationAdapter implements SaveReservationPort {
     }
 
     private void lockSeat(Reservation reservation) {
-        String key = "seat:" + reservation.getProgramId() + ":" + reservation.getTimesId() + ":" + reservation.getSectionId() + ":" + reservation.getSeatId();
+        String key = "reservation:" + reservation.getProgramId() + ":" + reservation.getTimesId() + ":" + reservation.getSectionId();
 
-        redisTemplate.opsForHash().put(key, "status", "LOCKED");
+        redisTemplate.opsForSet().add(key, reservation.getSeatId().toString());
 
+        // 만료 시간 설정
         redisTemplate.expire(key, Duration.ofMinutes(10));
     }
+
 
 
     private static ReservationEntity from(Reservation reservation) {

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/SaveReservationAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/SaveReservationAdapter.java
@@ -49,7 +49,7 @@ public class SaveReservationAdapter implements SaveReservationPort {
     }
 
     private void lockSeat(Reservation reservation) {
-        String key = "seat:" + reservation.getProgramId() + ":" + reservation.getTimesId() + ":" + reservation.getSectionId() + ":" + reservation.getTimesId();
+        String key = "seat:" + reservation.getProgramId() + ":" + reservation.getTimesId() + ":" + reservation.getSectionId() + ":" + reservation.getSeatId();
 
         redisTemplate.opsForHash().put(key, "status", "LOCKED");
 

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
@@ -29,6 +29,26 @@ public interface SectionRepository extends JpaRepository<SectionEntity, Long> {
             @Param("locationId") Long locationId,
             @Param("programId") Long programId
     );
+
+    @Query("SELECT NEW com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetSectionResponse(" +
+            "s.id, s.sectionName, s.gradeEntity.id, s.gradeEntity.gradeName, pg.price, " +
+            "(SELECT COUNT(seat.id) " +
+            " FROM SeatEntity seat " +
+            " LEFT JOIN ReservationEntity re ON seat.id = re.seatEntity.id AND re.programEntity.id = :programId " +
+            " WHERE seat.sectionEntity.id = s.id AND seat.active = TRUE " +
+            " AND (re.id IS NULL OR re.available = TRUE))) " +
+            "FROM SectionEntity s " +
+            "JOIN s.gradeEntity g " +
+            "JOIN ProgramGradeEntity pg ON g.id = pg.gradeEntity.id " +
+            "JOIN pg.programEntity p " +
+            "WHERE s.locationEntity.id = :locationId " +
+            "AND p.id = :programId")
+    List<GetSectionResponse> findAllByLocationEntityIdWithReservedCount(
+            @Param("locationId") Long locationId,
+            @Param("programId") Long programId);
+
+
+
     Boolean existsByIdAndLocationEntityId(Long sectionId, Long LocationId);
 
     @Query("SELECT s FROM SectionEntity s WHERE s.locationEntity.id = :locationId")

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSectionUseCase.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSectionUseCase.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface GetSectionUseCase {
 
-    List<Section> getSection(Long locationId, Long programId) throws BaseException;
+    List<Section> getSection(Long locationId, Long programId, Long timesId) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/VerifySeatCommand.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/VerifySeatCommand.java
@@ -11,4 +11,6 @@ public class VerifySeatCommand {
     private Long userId;
     private Long programId;
     private Long timesId;
+    private Long sectionId;
+    private Integer totalPrice;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSeatPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSeatPort.java
@@ -8,8 +8,6 @@ import java.util.List;
 public interface GetSeatPort {
     List<Seat> getAvailableSeatByQuery(Long programId, Long timesId, Long sectionId);
 
-    List<Seat> getAvailableSeatByJpa(Long programId, Long timesId, Long sectionId) throws BaseException;
-
     List<Seat> getAllSeat(Long sectionId) throws BaseException;
 
     List<Seat> getAllSeatWithEnable(Long programId, Long sectionId, Long timesId) throws BaseException;

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSectionPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSectionPort.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface GetSectionPort {
 
-    List<Section> getSection(Long locationId, Long programId) throws BaseException;
+    List<Section> getSection(Long locationId, Long programId, Long timesId) throws BaseException;
     Section getRowColumn(Long id) throws BaseException;
     void correctSection(Long sectionId, Long locationId) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/SaveReservationPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/SaveReservationPort.java
@@ -4,7 +4,7 @@ import com.gamja.tiggle.reservation.domain.Reservation;
 
 public interface SaveReservationPort {
 
-    Long save(Reservation reservation);
+    void save(Reservation reservation);
     void update(Reservation reservation);
 
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/GetSectionService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/GetSectionService.java
@@ -18,8 +18,8 @@ public class GetSectionService implements GetSectionUseCase {
     private final ProgramPort programPort;
 
     @Override
-    public List<Section> getSection(Long locationId, Long programId) throws BaseException {
+    public List<Section> getSection(Long locationId, Long programId, Long timesId) throws BaseException {
         programPort.findByProgramIdAndLocationId(programId,locationId);
-        return getSectionPort.getSection(locationId, programId);
+        return getSectionPort.getSection(locationId, programId, timesId);
     }
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/VerifySeatService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/VerifySeatService.java
@@ -28,14 +28,13 @@ public class VerifySeatService implements VerifySeatUseCase {
         //좌석 검증
         Seat seat = Seat.builder().id(command.getSeatId()).build();
         verifySeatPort.verifySeat(seat);
-        // TODO 유저 추가
 
         //검증했으면 예약 임시 저장
         String ticketNumber = getTicketNumber();
         Reservation reservation = from(command, ticketNumber);
-        Long id = saveReservationPort.save(reservation);
+        saveReservationPort.save(reservation);
 
-        return VerifySeatResponse.builder().reservationId(id).build();
+        return VerifySeatResponse.builder().ticketNumber(ticketNumber).build();
     }
 
     private static String getTicketNumber() {

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/VerifySeatService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/VerifySeatService.java
@@ -50,6 +50,8 @@ public class VerifySeatService implements VerifySeatUseCase {
                 .seatId(command.getSeatId())
                 .timesId(command.getTimesId())
                 .programId(command.getProgramId())
+                .sectionId(command.getSectionId())
+                .totalPrice(command.getTotalPrice())
                 .ticketNumber(ticketNumber)
                 .build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,16 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.mariadb.jdbc.Driver
+  data:
+    redis:
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
 
   jpa:
     defer-datasource-initialization: true
@@ -19,18 +29,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      password: ""
-      timeout: 5000
-      lettuce:
-        pool:
-          max-active: 8
-          max-idle: 8
-          min-idle: 0
-          max-wait: -1
 
   mail:
     host: smtp.gmail.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,18 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ""
+      timeout: 5000
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+          max-wait: -1
 
   mail:
     host: smtp.gmail.com


### PR DESCRIPTION
## 연관된 이슈
#17 
<br>

## 작업 내용
- Redis 도입 및 설정
  - 좌석 예약 정보를 효율적으로 관리하기 위해 Redis를 도입했습니다.
  - RedisConfig를 구현하여 연결 설정과 비밀번호 설정을 추가했습니다.
- 예약 정보 Redis 관리로 리팩토링
  - 기존 DB에 저장되던 예약 진행 중인 좌석 정보를 Redis에 저장하도록 수정했습니다.
  - 예약 진행 중인 좌석은 LOCKED 상태로 Redis의 Set에 저장되며, 10분을 설정해 자동 해제됩니다.
- 좌석 상태 관리 방식 개선
  - 좌석 관리 방식을 Hash에서 Set으로 변경해, 단순하게 예약 진행 중 좌석의 ID만 저장하도록 했습니다.
- 예약 가능 좌석 조회 로직 수정
  - 좌석 조회 시 Redis와 DB를 모두 참조하도록 변경했습니다.
  - DB: 활성화된 좌석(active=true) 및 예약 완료된 좌석 정보를 조회합니다.
  - Redis: 예약 진행 중인 좌석을 조회해 추가적으로 필터링합니다.
  - DB 결과에 Redis 상태를 반영하여 최종 결과를 반환하도록 구현했습니다.
- 잔여 좌석 조회 로직 개선
  - Section별 잔여 좌석 조회 시 Redis의 예약 진행 중 좌석 데이터를 고려하도록 수정했습니다.
  - Redis에서 예약 진행 중 좌석의 수를 조회합니다.
  - Redis 데이터를 DB 결과에서 차감하여 잔여 좌석 개수를 정확히 계산합니다.
- 코드 리팩토링
  - 중복된 로직을 제거하고 코드 가독성을 개선했습니다.
  - 좌석 관리 로직을 Redis 중심으로 재구성하여 성능을 최적화했습니다.
<br> 

## 전달 사항
- 예매 과정은 좌석 선택에서 끝나는 것이 아니라 결제까지 이어지는 프로세스를 포함합니다. Redis 도입으로 인해 변경된 구조를 기반으로, 결제 이후의 로직도 적합하게 수정할 예정입니다.
- Redis를 도입하여 좌석 예약 상태를 관리하는 만큼, 프로젝트 실행 시 Redis 서버와의 연결이 필요합니다.
  - yml 파일에 환경변수를 설정해 Redis 서버의 비밀번호, 호스트, 포트 등의 정보를 정확히 입력해야 합니다.
  - Redis 서버가 실행 중인지 확인하고, 필요한 경우 로컬 또는 외부 서버에서 Redis를 설정해야 합니다.
  
close #17 