### PR TITLE
[Refactor] Redis 연동을 통한 임시 예매 내역 조회 로직 개선

### DIFF
--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/ReadReservationController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/ReadReservationController.java
@@ -9,6 +9,7 @@ import com.gamja.tiggle.reservation.adapter.in.web.response.ReadReservationRespo
 import com.gamja.tiggle.reservation.adapter.in.web.response.ReadTemporaryReservationResponse;
 import com.gamja.tiggle.reservation.application.port.in.ReadReservationCommand;
 import com.gamja.tiggle.reservation.application.port.in.ReadReservationUseCase;
+import com.gamja.tiggle.reservation.application.port.in.ReadTemporaryReservationCommand;
 import com.gamja.tiggle.reservation.domain.Reservation;
 import com.gamja.tiggle.user.domain.CustomUserDetails;
 import com.gamja.tiggle.user.domain.User;
@@ -69,11 +70,12 @@ public class ReadReservationController {
 
     @GetMapping("/temporary")
     @Operation(summary = "임시 예매 내역 조회", description = "ReservationId를 입력하여 진행중인 예매 내역을 조회하는 API 입니다.")
-    public BaseResponse<ReadTemporaryReservationResponse> readTemporary(@RequestParam Long reservationId) {
+    public BaseResponse<ReadTemporaryReservationResponse> readTemporary(@RequestParam String ticketNumber) {
+
         try {
 
-            ReadReservationCommand command = ReadReservationCommand.builder()
-                    .reservationId(reservationId)
+            ReadTemporaryReservationCommand command = ReadTemporaryReservationCommand.builder()
+                    .ticketNumber(ticketNumber)
                     .build();
 
             Reservation reservation = readReservationUseCase.readTemporaryReservation(command);

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/ReadReservationUseCase.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/ReadReservationUseCase.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface ReadReservationUseCase {
     Reservation readReservation(ReadReservationCommand command) throws BaseException;
-    Reservation readTemporaryReservation(ReadReservationCommand command) throws BaseException;
+    Reservation readTemporaryReservation(ReadTemporaryReservationCommand command) throws BaseException;
     List<Reservation> myRead(ReadReservationCommand command) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/ReadTemporaryReservationCommand.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/ReadTemporaryReservationCommand.java
@@ -1,0 +1,13 @@
+package com.gamja.tiggle.reservation.application.port.in;
+
+import com.gamja.tiggle.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class ReadTemporaryReservationCommand {
+    private User user;
+    private String ticketNumber;
+}

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/ReadReservationPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/ReadReservationPort.java
@@ -3,6 +3,7 @@ import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
 import com.gamja.tiggle.reservation.application.port.in.ReadReservationCommand;
 import com.gamja.tiggle.reservation.domain.Reservation;
+
 import java.util.List;
 
 
@@ -11,5 +12,5 @@ public interface ReadReservationPort {
     Reservation readReservation(Reservation reservation) throws  BaseException;
     List<Reservation> myRead(ReadReservationCommand command) throws BaseException;
     Long getReservationCnt(Long userid) throws BaseException;
-    Reservation readTemporaryReservation(Reservation reservation);
+    Reservation readTemporaryReservation(Reservation reservation) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/ReadReservationService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/ReadReservationService.java
@@ -5,6 +5,7 @@ import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.common.annotation.UseCase;
 import com.gamja.tiggle.reservation.application.port.in.ReadReservationCommand;
 import com.gamja.tiggle.reservation.application.port.in.ReadReservationUseCase;
+import com.gamja.tiggle.reservation.application.port.in.ReadTemporaryReservationCommand;
 import com.gamja.tiggle.reservation.application.port.out.ReadReservationPort;
 import com.gamja.tiggle.reservation.domain.Reservation;
 import com.gamja.tiggle.user.domain.User;
@@ -26,9 +27,9 @@ public class ReadReservationService implements ReadReservationUseCase {
     }
 
     @Override
-    public Reservation readTemporaryReservation(ReadReservationCommand command) throws BaseException {
+    public Reservation readTemporaryReservation(ReadTemporaryReservationCommand command) throws BaseException {
         Reservation reservation = Reservation.builder()
-                .id(command.getReservationId())
+                .ticketNumber(command.getTicketNumber())
                 .build();
         return readReservationPort.readTemporaryReservation(reservation);
     }


### PR DESCRIPTION
## 연관된 이슈
#17 
<br>

## 작업 내용
- 기존 DB 조회 로직 수정
  - 기존에 DB에서 데이터를 가져오던 로직을 Redis에서 데이터를 조회하도록 변경했습니다.
  - Redis에서 데이터를 조회하고 필요한 정보를 변환하여 반환하는 방식으로 리팩토링했습니다.
  - Redis 조회 및 변환 로직을 위해 새로운 Command를 구현했습니다.
- 예외 처리 추가
  - Redis에서 데이터가 없을 경우 예외를 던지도록 로직을 추가했습니다.
  - 기존의 DB 조회 방식 대비 안정성을 유지하기 위해 예외 처리를 구현했습니다.

<br> 

## 전달 사항
