### PR TITLE
[Refactor] 좌석 예약 동시성 제어 강화를 위한 Redis 분산 락 및 Atomic Operation 도입 [#17]

### DIFF
--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSeatAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSeatAdapter.java
@@ -93,7 +93,7 @@ public class GetSeatAdapter implements GetSeatPort {
     @NotNull
     private List<Seat> getSeatListWithRedisStatus(Long programId, Long timesId, Long sectionId, List<GetAllSeatPersistentResponse> allSeat) {
 
-        String redisKey = "reservation:" + programId + ":" + timesId + ":" + sectionId;
+        String redisKey = "seat:" + programId + ":" + timesId + ":" + sectionId;
 
         return allSeat.stream().map(response -> {
             boolean isLocked = redisTemplate.opsForSet().isMember(redisKey, response.getSeatId().toString());

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
@@ -50,7 +50,7 @@ public class GetSectionAdapter implements GetSectionPort {
     }
 
     private Long countInProgressReservations(Long programId, Long timesId, Long sectionId) {
-        String redisKey = "reservation:" + programId + ":" + timesId + ":" + sectionId;
+        String redisKey = "seat:" + programId + ":" + timesId + ":" + sectionId;
 
         return redisTemplate.opsForSet().size(redisKey);
     }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/SaveReservationPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/SaveReservationPort.java
@@ -1,10 +1,11 @@
 package com.gamja.tiggle.reservation.application.port.out;
 
+import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.reservation.domain.Reservation;
 
 public interface SaveReservationPort {
 
-    void save(Reservation reservation);
+    void save(Reservation reservation) throws BaseException;
     void update(Reservation reservation);
 
 }


### PR DESCRIPTION
## 연관된 이슈
#17 
<br>

## 작업 내용
- 기존 코드에서는 좌석 예약 시 Redis Set 자료구조를 활용했지만, 다음과 같은 동시성 문제가 있었습니다.
  - 동일 좌석에 대해 여러 클라이언트가 동시에 접근하면 중복 예약이 발생할 가능성이 있었습니다.
  - Atomic Operation(원자적 동작)을 보장하지 않아 작업의 일관성과 안정성이 부족했습니다.
- Redis 분산 락을 도입했습니다
  - 한 번에 하나의 클라이언트만 동일 좌석 작업을 수행할 수 있도록 제한했습니다.
  - 작업 완료 후 락을 해제해 자원을 효율적으로 관리하고 충돌을 방지했습니다.
- Redis Set의 Atomic Operation을 활용했습니다
  - opsForSet().add()를 사용해 좌석 상태 확인 및 업데이트를 Atomic하게 처리했습니다.
  - 이미 예약된 좌석에 대해 중복 추가를 방지해 데이터 무결성을 확보했습니다.
<br> 

## 전달 사항
